### PR TITLE
Added multiple ES containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,11 @@
 version: "3.8"
 
 services:
-  elasticsearch:
+  es01:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.13.2
-    container_name: elasticsearch
+    container_name: es01
     environment:
-      - node.name=elasticsearch
+      - node.name=es01
       - cluster.name=es-docker-cluster
       - discovery.seed_hosts=es02,es03
       - cluster.initial_master_nodes=es01,es02,es03
@@ -20,9 +20,45 @@ services:
     ports:
       - 9200:9200
     networks:
-      - backend
-    logging:
-      driver: none
+      - elastic
+  es02:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.2
+    container_name: es02
+    environment:
+      - node.name=es02
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es01,es03
+      - cluster.initial_master_nodes=es01,es02,es03
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data02:/usr/share/elasticsearch/data
+    networks:
+      - elastic
+  es03:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.2
+    container_name: es03
+    environment:
+      - node.name=es03
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es01,es02
+      - cluster.initial_master_nodes=es01,es02,es03
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data03:/usr/share/elasticsearch/data
+    networks:
+      - elastic
+
+
 
   api:
     container_name: api
@@ -34,14 +70,17 @@ services:
       - ./api:/go/src/elastic_books/api
     ports:
       - "8080:8080"
-    depends_on:
-      - elasticsearch
     networks:
-      - backend
+      - elastic
 
 volumes:
   data01:
+    driver: local
+  data02:
+    driver: local
+  data03:
+    driver: local
 
 networks:
-  backend:
+  elastic:
     driver: bridge


### PR DESCRIPTION
Resolves #6 

ES is meant to be used with multiple containers where each Lucene server is in charge of a part of the documents.